### PR TITLE
chore(bot): handle mainline events

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ var (
 	owner      string
 	repository string
 	mergeLabel string
+	mainline   string
 
 	cache *repo.Cache
 )
@@ -39,6 +40,7 @@ func main() {
 	flag.StringVar(&publicDNS, "public-dns", "", "publicly accessible dns endpoint for webhook push")
 	flag.StringVar(&mergeLabel, "merge-label", "", "which label is checked to kick off the merge process")
 	flag.StringVar(&addr, "addr", "", "address to listen on")
+	flag.StringVar(&mainline, "mainline", "master", "main branch")
 	flag.Parse()
 
 	if token == "" {

--- a/push_event.go
+++ b/push_event.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/github"
+)
+
+func processPushEvent(client PullRequestLister, input <-chan *github.PushEvent) <-chan *github.PullRequest {
+	ret := make(chan *github.PullRequest)
+	go func() {
+		for evt := range input {
+
+			if evt.GetRef() != fmt.Sprintf("refs/heads/%s", mainline) {
+				continue
+			}
+
+			prs, _, err := client.List(
+				context.Background(),
+				owner,
+				repository,
+				&github.PullRequestListOptions{
+					State: "open",
+				})
+			if err != nil {
+				continue
+			}
+			for _, pr := range prs {
+				ret <- pr
+			}
+		}
+
+		close(ret)
+	}()
+	return ret
+}

--- a/push_event_test.go
+++ b/push_event_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-github/github"
+)
+
+func TestProcessPushEvent(t *testing.T) {
+	ch := make(chan *github.PushEvent, 1)
+
+	t.Run("adds open PRs on mainline push", func(t *testing.T) {
+		mainline = "master"
+		out := processPushEvent(fakePullRequestResponse(2), ch)
+		ch <- &github.PushEvent{
+			Ref: stringVal("refs/heads/master"),
+		}
+		close(ch)
+
+		if _, ok := <-out; !ok {
+			t.Fatal("Expected output on PR, but didn't receive")
+		}
+		if _, ok := <-out; !ok {
+			t.Fatal("Expected output on PR, but didn't receive")
+		}
+	})
+}

--- a/status_event.go
+++ b/status_event.go
@@ -6,6 +6,59 @@ import (
 	"github.com/google/go-github/github"
 )
 
+type statusEventBroadcaster struct {
+	listeners []chan<- *github.StatusEvent
+}
+
+func (b *statusEventBroadcaster) Listen(in <-chan *github.StatusEvent) {
+	for evt := range in {
+		for _, l := range b.listeners {
+			l <- evt
+		}
+	}
+
+	for _, l := range b.listeners {
+		close(l)
+	}
+}
+
+// processMainlineStatusEvent takes mainline status events and emits open PRs
+func processMainlineStatusEvent(client PullRequestLister, input <-chan *github.StatusEvent) <-chan *github.PullRequest {
+	ret := make(chan *github.PullRequest)
+	go func() {
+		for evt := range input {
+			if evt.GetState() != "success" {
+				continue
+			}
+
+			isMainline := false
+			for _, branch := range evt.Branches {
+				isMainline = isMainline || *branch.Name == mainline
+			}
+
+			if !isMainline {
+				continue
+			}
+
+			prs, _, err := client.List(
+				context.Background(),
+				owner,
+				repository,
+				&github.PullRequestListOptions{
+					State: "open",
+				})
+			if err != nil {
+				continue
+			}
+			for _, pr := range prs {
+				ret <- pr
+			}
+		}
+		close(ret)
+	}()
+	return ret
+}
+
 // processStatusEvent filters out non-successful commits to PRs
 func processStatusEvent(client PullRequestLister, input <-chan *github.StatusEvent) <-chan *github.PullRequest {
 	ret := make(chan *github.PullRequest)

--- a/status_event_test.go
+++ b/status_event_test.go
@@ -3,15 +3,77 @@ package main
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/google/go-github/github"
 )
 
+func TestStatusEventBroadcaster(t *testing.T) {
+	inp := make(chan *github.StatusEvent)
+	q1 := make(chan *github.StatusEvent)
+	q2 := make(chan *github.StatusEvent)
+	b := statusEventBroadcaster{listeners: []chan<- *github.StatusEvent{q1, q2}}
+	go b.Listen(inp)
+	defer close(inp)
+
+	w := sync.WaitGroup{}
+	w.Add(2)
+	go func() {
+		<-q1
+		w.Done()
+	}()
+	go func() {
+		<-q2
+		w.Done()
+	}()
+	inp <- &github.StatusEvent{}
+	w.Wait()
+}
+
+func TestProcessMainlineStatusEvent(t *testing.T) {
+	ch := make(chan *github.StatusEvent, 1)
+
+	t.Run("adds open PRs on mainline success", func(t *testing.T) {
+		mainline = "master"
+		out := processMainlineStatusEvent(fakePullRequestResponse(2), ch)
+		ch <- &github.StatusEvent{
+			State: stringVal("success"),
+			Branches: []*github.Branch{
+				{
+					Name: stringVal("master"),
+				},
+			},
+		}
+		close(ch)
+
+		if _, ok := <-out; !ok {
+			t.Fatal("Expected output on PR, but didn't receive")
+		}
+		if _, ok := <-out; !ok {
+			t.Fatal("Expected output on PR, but didn't receive")
+		}
+	})
+}
+
 type fakePullRequestLister func() ([]*github.PullRequest, *github.Response, error)
 
 func (f fakePullRequestLister) List(ctx context.Context, _ string, _ string, _ *github.PullRequestListOptions) ([]*github.PullRequest, *github.Response, error) {
 	return f()
+}
+
+func fakePullRequestResponse(n int) fakePullRequestLister {
+	return fakePullRequestLister(func() ([]*github.PullRequest, *github.Response, error) {
+		reqs := []*github.PullRequest{}
+		for i := 0; i < n; i++ {
+			reqs = append(reqs, &github.PullRequest{
+				Head: &github.PullRequestBranch{
+					Ref: stringVal("test"),
+				},
+			})
+		}
+		return reqs, nil, nil
+	})
 }
 
 func TestProcessStatusEvent_Filters(t *testing.T) {
@@ -54,15 +116,7 @@ func TestProcessStatusEvent_Filters(t *testing.T) {
 func TestProcessStatusEvent_PassThrough(t *testing.T) {
 	ch := make(chan *github.StatusEvent, 1)
 
-	prs := processStatusEvent(fakePullRequestLister(func() ([]*github.PullRequest, *github.Response, error) {
-		return []*github.PullRequest{
-			{
-				Head: &github.PullRequestBranch{
-					Ref: stringVal("test"),
-				},
-			},
-		}, nil, nil
-	}), ch)
+	prs := processStatusEvent(fakePullRequestResponse(1), ch)
 	ch <- &github.StatusEvent{
 		State: stringVal("success"),
 		Branches: []*github.Branch{


### PR DESCRIPTION
when changes occur on the mainline we need to re-evaluate the open pull-requests.
this PR will introduce this handling