### PR TITLE
indicate rebase errors inside PR

### DIFF
--- a/processors/rebase.go
+++ b/processors/rebase.go
@@ -1,46 +1,46 @@
 package processors
 
 import (
-	"log"
+	"errors"
 	"sync"
 
 	"github.com/google/go-github/github"
 	"github.com/nicolai86/github-rebase-bot/repo"
 )
 
+type RebaseResult struct {
+	PR    *github.PullRequest
+	Error error
+}
+
+var ErrMainlineChanged = errors.New("mainline changed during rebase")
+
 // Rebase rebases a pull request with mainline.
 // if the rebase is possible the changes are pushed to github.
 // when no rebase was necessary the PR is emitted
-func Rebase(r Repository, in <-chan *github.PullRequest) <-chan *github.PullRequest {
-	ret := make(chan *github.PullRequest)
-
-	input := make(chan *github.PullRequest)
-	go func() {
-		for pr := range in {
-			input <- pr
-		}
-		close(input)
-	}()
+func Rebase(r Repository, in <-chan *github.PullRequest) <-chan RebaseResult {
+	ret := make(chan RebaseResult)
 
 	go func() {
 		wg := sync.WaitGroup{}
-		for pr := range input {
+
+		for pr := range in {
 			cache := r.Cache
 			w, err := cache.Worker(pr.Head.GetRef())
 			if err != nil {
+				ret <- RebaseResult{pr, err}
+				continue
+			}
+
+			rev, err := cache.Update()
+			if err != nil {
+				ret <- RebaseResult{pr, err}
 				continue
 			}
 
 			c := make(chan repo.Signal, 1)
-
-			rev, err := cache.Update()
-			if err != nil {
-				log.Printf("failed to update: %v", err)
-				continue
-			}
-
-			w.Enqueue(c)
 			wg.Add(1)
+			w.Enqueue(c)
 			go func(pr *github.PullRequest, rev string) {
 				defer wg.Done()
 				sig := <-c
@@ -48,12 +48,16 @@ func Rebase(r Repository, in <-chan *github.PullRequest) <-chan *github.PullRequ
 				rev2, _ := cache.Update()
 				if rev != rev2 {
 					// mainline changed while we were processing this PR. re-process to handle cont. rebasing
-					input <- pr
+					ret <- RebaseResult{pr, ErrMainlineChanged}
 					return
 				}
 
-				if sig.UpToDate && sig.Error == nil {
-					ret <- pr
+				if sig.Error != nil {
+					ret <- RebaseResult{pr, sig.Error}
+					return
+				}
+				if sig.UpToDate {
+					ret <- RebaseResult{pr, nil}
 				}
 			}(pr, rev)
 		}

--- a/processors/rebase_test.go
+++ b/processors/rebase_test.go
@@ -89,7 +89,7 @@ func TestRebase(t *testing.T) {
 			},
 		}
 		close(ch)
-		if v, ok := (<-ret); v != nil || ok {
+		if v, ok := (<-ret); v.Error == nil || !ok {
 			t.Fatal("Expected pull request to be skipped")
 		}
 	})
@@ -115,7 +115,7 @@ func TestRebase(t *testing.T) {
 			},
 		}
 		close(ch)
-		if v, ok := (<-ret); v != nil || ok {
+		if v, ok := (<-ret); v.Error != nil || ok {
 			t.Fatal("Expected pull request to be skipped")
 		}
 	})
@@ -141,7 +141,7 @@ func TestRebase(t *testing.T) {
 			},
 		}
 		close(ch)
-		if v, ok := (<-ret); v != nil || ok {
+		if v, ok := (<-ret); v.Error == nil || !ok {
 			t.Fatal("Expected pull request to be skipped")
 		}
 	})
@@ -167,7 +167,7 @@ func TestRebase(t *testing.T) {
 			},
 		}
 		close(ch)
-		if v, ok := (<-ret); v == nil || !ok {
+		if v, ok := (<-ret); v.Error != nil || !ok {
 			t.Fatal("Expected pull request to pass through")
 		}
 	})


### PR DESCRIPTION
right now the bot doesn't show when he can't rebase a PR due to conflicts. 
Adding a comment to the PR would probably be a good first step.

There's an updated dockerhub image which contains the new feature from this branch:
`nicolai86/github-rebase-bot:v0.0.4-2`