### PR TITLE
bug(hooks): subscribe for all webhook events

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,12 +121,7 @@ func createHook(client *github.Client, publicDNS, owner, repo string) (*github.H
 			"url":          fmt.Sprintf("%s/events", publicDNS),
 			"content_type": "json",
 		},
-		Events: []string{
-			"pull_request",
-			"status",
-			"pull_request_review",
-			"issues",
-		},
+		Events: []string{"*"},
 	})
 	return hook, err
 }


### PR DESCRIPTION
easier to filter on the client side than to manage the remote webhook