### PR TITLE
feat(bot) support multiple github repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.5
 
 RUN apk --no-cache --update add ca-certificates git curl && update-ca-certificates
 
-ENV GITHUB_TOKEN="" GITHUB_OWNER="" GITHUB_REPO="" GITHUB_MERGE_LABEL="LGTM" GITHUB_MAINLINE="master" PUBLIC_DNS=""
+ENV GITHUB_TOKEN="" GITHUB_OWNER="" GITHUB_REPOS="" GITHUB_MERGE_LABEL="LGTM" PUBLIC_DNS=""
 ADD github-rebase-bot startup.sh /
 
 ENTRYPOINT ["/startup.sh"]

--- a/event.go
+++ b/event.go
@@ -112,12 +112,12 @@ func prHandler(r repository, client *github.Client) http.HandlerFunc {
 		}
 	}()
 
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		eventType := r.Header.Get("X-GitHub-Event")
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		eventType := req.Header.Get("X-GitHub-Event")
 
 		if eventType == "pull_request" {
 			evt := new(github.PullRequestEvent)
-			json.NewDecoder(r.Body).Decode(evt)
+			json.NewDecoder(req.Body).Decode(evt)
 
 			prQueue <- evt.PullRequest
 
@@ -127,26 +127,26 @@ func prHandler(r repository, client *github.Client) http.HandlerFunc {
 			}
 		} else if eventType == "pull_request_review" {
 			evt := new(github.PullRequestReviewEvent)
-			json.NewDecoder(r.Body).Decode(evt)
+			json.NewDecoder(req.Body).Decode(evt)
 
 			reviewQueue <- evt
 		} else if eventType == "issues" {
 			evt := new(github.IssuesEvent)
-			json.NewDecoder(r.Body).Decode(evt)
+			json.NewDecoder(req.Body).Decode(evt)
 
 			issueQueue <- evt
 		} else if eventType == "status" {
 			evt := new(github.StatusEvent)
-			json.NewDecoder(r.Body).Decode(evt)
+			json.NewDecoder(req.Body).Decode(evt)
 
 			statusEventQueue <- evt
 		} else if eventType == "push" {
 			evt := new(github.PushEvent)
-			json.NewDecoder(r.Body).Decode(evt)
+			json.NewDecoder(req.Body).Decode(evt)
 
 			pushEventQueue <- evt
 		} else {
-			log.Printf("Event %s not supported yet.\n", eventType)
+			log.Printf("%s/%s: Event %s not supported yet.\n", r.owner, r.name, eventType)
 		}
 	})
 }

--- a/event.go
+++ b/event.go
@@ -56,7 +56,7 @@ func processMerge(client *github.Client, input <-chan *github.PullRequest) <-cha
 	return ret
 }
 
-func prHandler(client *github.Client) http.HandlerFunc {
+func prHandler(r repository, client *github.Client) http.HandlerFunc {
 	issueQueue := make(chan *github.IssuesEvent, 100)
 	prQueue := make(chan *github.PullRequest, 100)
 	reviewQueue := make(chan *github.PullRequestReviewEvent, 100)
@@ -80,15 +80,15 @@ func prHandler(client *github.Client) http.HandlerFunc {
 	//  - mergeable
 	rebaseQueue := verifyPullRequest(client.Issues, client.Repositories, mergeLabel, merge(
 		prQueue,
-		processMainlineStatusEvent(repos, client.PullRequests, mainlineStatusEventQueue),
+		processMainlineStatusEvent(r, client.PullRequests, mainlineStatusEventQueue),
 		processIssuesEvent(client.PullRequests, issueQueue),
 		processStatusEvent(client.PullRequests, statusPRQueue),
-		processPushEvent(repos, client.PullRequests, pushEventQueue),
+		processPushEvent(r, client.PullRequests, pushEventQueue),
 		processPullRequestReviewEvent(client, reviewQueue),
 	))
 
 	doneQueue := processMerge(client,
-		processRebase(repos, rebaseQueue),
+		processRebase(r, rebaseQueue),
 	)
 
 	go func() {

--- a/issues_event.go
+++ b/issues_event.go
@@ -13,8 +13,8 @@ func processIssuesEvent(client PullRequestGetter, input <-chan *github.IssuesEve
 		for evt := range input {
 			pr, _, err := client.Get(
 				context.Background(),
-				owner,
-				repository,
+				evt.Repo.Owner.GetLogin(),
+				evt.Repo.GetName(),
 				evt.Issue.GetNumber())
 			if pr == nil || err != nil {
 				continue

--- a/issues_event_test.go
+++ b/issues_event_test.go
@@ -21,6 +21,12 @@ func TestProcessIssuesEvent_Filter(t *testing.T) {
 		Issue: &github.Issue{
 			Number: intVal(1),
 		},
+		Repo: &github.Repository{
+			Name: stringVal("test"),
+			Owner: &github.User{
+				Login: stringVal("test"),
+			},
+		},
 	}
 
 	ch := make(chan *github.IssuesEvent, 1)
@@ -43,6 +49,12 @@ func TestProcessIssuesEvent_PassThrough(t *testing.T) {
 	evt := github.IssuesEvent{
 		Issue: &github.Issue{
 			Number: intVal(1),
+		},
+		Repo: &github.Repository{
+			Name: stringVal("test"),
+			Owner: &github.User{
+				Login: stringVal("test"),
+			},
 		},
 	}
 

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -15,10 +15,8 @@ spec:
         - name: rebase-bot
           image: nicolai86/github-rebase-bot:v0.0.3
           env:
-            - name: GITHUB_OWNER
-              value: nicolai86
-            - name: GITHUB_REPO
-              value: github-rebase-bot
+            - name: GITHUB_REPOS
+              value: nicolai86/github-rebase-bot
             - name: GITHUB_MERGE_LABEL
               value: LGTM
             - name: GITHUB_MAINLINE

--- a/push_event.go
+++ b/push_event.go
@@ -7,19 +7,20 @@ import (
 	"github.com/google/go-github/github"
 )
 
-func processPushEvent(client PullRequestLister, input <-chan *github.PushEvent) <-chan *github.PullRequest {
+func processPushEvent(repos repositories, client PullRequestLister, input <-chan *github.PushEvent) <-chan *github.PullRequest {
 	ret := make(chan *github.PullRequest)
 	go func() {
 		for evt := range input {
 
-			if evt.GetRef() != fmt.Sprintf("refs/heads/%s", mainline) {
+			repo := repos.Find(evt.Repo.Owner.GetName(), evt.Repo.GetName())
+			if evt.GetRef() != fmt.Sprintf("refs/heads/%s", repo.mainline) {
 				continue
 			}
 
 			prs, _, err := client.List(
 				context.Background(),
-				owner,
-				repository,
+				repo.owner,
+				repo.name,
 				&github.PullRequestListOptions{
 					State: "open",
 				})

--- a/push_event.go
+++ b/push_event.go
@@ -7,12 +7,11 @@ import (
 	"github.com/google/go-github/github"
 )
 
-func processPushEvent(repos repositories, client PullRequestLister, input <-chan *github.PushEvent) <-chan *github.PullRequest {
+func processPushEvent(repo repository, client PullRequestLister, input <-chan *github.PushEvent) <-chan *github.PullRequest {
 	ret := make(chan *github.PullRequest)
 	go func() {
 		for evt := range input {
 
-			repo := repos.Find(evt.Repo.Owner.GetName(), evt.Repo.GetName())
 			if evt.GetRef() != fmt.Sprintf("refs/heads/%s", repo.mainline) {
 				continue
 			}

--- a/push_event_test.go
+++ b/push_event_test.go
@@ -9,12 +9,26 @@ import (
 func TestProcessPushEvent(t *testing.T) {
 	ch := make(chan *github.PushEvent, 1)
 
+	repos := repositories{
+		{
+			owner:    "test",
+			name:     "test",
+			mainline: "master",
+		},
+	}
+
 	t.Run("adds open PRs on mainline push", func(t *testing.T) {
-		mainline = "master"
-		out := processPushEvent(fakePullRequestResponse(2), ch)
+		out := processPushEvent(repos, fakePullRequestResponse(2), ch)
 		ch <- &github.PushEvent{
 			Ref: stringVal("refs/heads/master"),
+			Repo: &github.PushEventRepository{
+				Name: stringVal("test"),
+				Owner: &github.PushEventRepoOwner{
+					Name: stringVal("test"),
+				},
+			},
 		}
+
 		close(ch)
 
 		if _, ok := <-out; !ok {

--- a/push_event_test.go
+++ b/push_event_test.go
@@ -9,16 +9,12 @@ import (
 func TestProcessPushEvent(t *testing.T) {
 	ch := make(chan *github.PushEvent, 1)
 
-	repos := repositories{
-		{
+	t.Run("adds open PRs on mainline push", func(t *testing.T) {
+		out := processPushEvent(repository{
 			owner:    "test",
 			name:     "test",
 			mainline: "master",
-		},
-	}
-
-	t.Run("adds open PRs on mainline push", func(t *testing.T) {
-		out := processPushEvent(repos, fakePullRequestResponse(2), ch)
+		}, fakePullRequestResponse(2), ch)
 		ch <- &github.PushEvent{
 			Ref: stringVal("refs/heads/master"),
 			Repo: &github.PushEventRepository{

--- a/rebase.go
+++ b/rebase.go
@@ -14,7 +14,7 @@ type WorkerCache interface {
 	Cleanup(repo.GitWorktree) error
 }
 
-func processRebase(rs repositories, in <-chan *github.PullRequest) <-chan *github.PullRequest {
+func processRebase(r repository, in <-chan *github.PullRequest) <-chan *github.PullRequest {
 	ret := make(chan *github.PullRequest)
 
 	input := make(chan *github.PullRequest)
@@ -28,7 +28,7 @@ func processRebase(rs repositories, in <-chan *github.PullRequest) <-chan *githu
 	go func() {
 		wg := sync.WaitGroup{}
 		for pr := range input {
-			cache := rs.Find(pr.Base.Repo.Owner.GetLogin(), pr.Base.Repo.GetName()).cache
+			cache := r.cache
 			w, err := cache.Worker(pr.Head.GetRef())
 			if err != nil {
 				continue

--- a/rebase.go
+++ b/rebase.go
@@ -11,9 +11,10 @@ import (
 type WorkerCache interface {
 	Worker(string) (repo.Enqueuer, error)
 	Update() (string, error)
+	Cleanup(repo.GitWorktree) error
 }
 
-func processRebase(cache WorkerCache, in <-chan *github.PullRequest) <-chan *github.PullRequest {
+func processRebase(rs repositories, in <-chan *github.PullRequest) <-chan *github.PullRequest {
 	ret := make(chan *github.PullRequest)
 
 	input := make(chan *github.PullRequest)
@@ -27,6 +28,7 @@ func processRebase(cache WorkerCache, in <-chan *github.PullRequest) <-chan *git
 	go func() {
 		wg := sync.WaitGroup{}
 		for pr := range input {
+			cache := rs.Find(pr.Base.Repo.Owner.GetLogin(), pr.Base.Repo.GetName()).cache
 			w, err := cache.Worker(pr.Head.GetRef())
 			if err != nil {
 				continue
@@ -36,7 +38,7 @@ func processRebase(cache WorkerCache, in <-chan *github.PullRequest) <-chan *git
 
 			rev, err := cache.Update()
 			if err != nil {
-				log.Printf("failed to update %q: %v", mainline, err)
+				log.Printf("failed to update: %v", err)
 				continue
 			}
 

--- a/rebase_test.go
+++ b/rebase_test.go
@@ -18,6 +18,9 @@ func (f fakeWorkerCache) Worker(branch string) (repo.Enqueuer, error) {
 func (f fakeWorkerCache) Update() (string, error) {
 	return "", nil
 }
+func (f fakeWorkerCache) Cleanup(v repo.GitWorktree) error {
+	return nil
+}
 
 type fakeEnqueuer func() repo.Signal
 
@@ -27,23 +30,40 @@ func (f fakeEnqueuer) Enqueue(c chan repo.Signal) {
 }
 
 func TestProcessRebase(t *testing.T) {
+
 	t.Run("requests a branch specific worker", func(t *testing.T) {
 		ch := make(chan *github.PullRequest)
 		prBranch := "super-feature"
 		prNumber := 2202
 		var wg sync.WaitGroup
 		wg.Add(1)
-		processRebase(fakeWorkerCache(func(branch string) (repo.Enqueuer, error) {
-			wg.Done()
-			if prBranch != branch {
-				t.Fatalf("Expected branch %q but got %q ", prBranch, branch)
-			}
-			return nil, errors.New("failed to checkout repo")
-		}), ch)
+		repos := repositories{
+			{
+				owner:    "test",
+				name:     "test",
+				mainline: "master",
+				cache: fakeWorkerCache(func(branch string) (repo.Enqueuer, error) {
+					wg.Done()
+					if prBranch != branch {
+						t.Fatalf("Expected branch %q but got %q ", prBranch, branch)
+					}
+					return nil, errors.New("failed to checkout repo")
+				}),
+			},
+		}
+		processRebase(repos, ch)
 		ch <- &github.PullRequest{
 			Number: intVal(prNumber),
 			Head: &github.PullRequestBranch{
 				Ref: stringVal(prBranch),
+			},
+			Base: &github.PullRequestBranch{
+				Repo: &github.Repository{
+					Name: stringVal("test"),
+					Owner: &github.User{
+						Login: stringVal("test"),
+					},
+				},
 			},
 		}
 		close(ch)
@@ -52,10 +72,27 @@ func TestProcessRebase(t *testing.T) {
 
 	t.Run("filters when worker fetching errors", func(t *testing.T) {
 		ch := make(chan *github.PullRequest)
-		ret := processRebase(fakeWorkerCache(func(_ string) (repo.Enqueuer, error) {
-			return nil, errors.New("failed to checkout repo")
-		}), ch)
-		ch <- &github.PullRequest{}
+		repos := repositories{
+			{
+				owner:    "test",
+				name:     "test",
+				mainline: "master",
+				cache: fakeWorkerCache(func(_ string) (repo.Enqueuer, error) {
+					return nil, errors.New("failed to checkout repo")
+				}),
+			},
+		}
+		ret := processRebase(repos, ch)
+		ch <- &github.PullRequest{
+			Base: &github.PullRequestBranch{
+				Repo: &github.Repository{
+					Name: stringVal("test"),
+					Owner: &github.User{
+						Login: stringVal("test"),
+					},
+				},
+			},
+		}
 		close(ch)
 		if v, ok := (<-ret); v != nil || ok {
 			t.Fatal("Expected pull request to be skipped")
@@ -64,10 +101,26 @@ func TestProcessRebase(t *testing.T) {
 
 	t.Run("filters rebased branches", func(t *testing.T) {
 		ch := make(chan *github.PullRequest)
-		ret := processRebase(fakeWorkerCache(func(branch string) (repo.Enqueuer, error) {
-			return fakeEnqueuer(func() repo.Signal { return repo.Signal{UpToDate: false} }), nil
-		}), ch)
-		ch <- &github.PullRequest{}
+		ret := processRebase(repositories{
+			{
+				owner:    "test",
+				name:     "test",
+				mainline: "master",
+				cache: fakeWorkerCache(func(branch string) (repo.Enqueuer, error) {
+					return fakeEnqueuer(func() repo.Signal { return repo.Signal{UpToDate: false} }), nil
+				}),
+			},
+		}, ch)
+		ch <- &github.PullRequest{
+			Base: &github.PullRequestBranch{
+				Repo: &github.Repository{
+					Name: stringVal("test"),
+					Owner: &github.User{
+						Login: stringVal("test"),
+					},
+				},
+			},
+		}
 		close(ch)
 		if v, ok := (<-ret); v != nil || ok {
 			t.Fatal("Expected pull request to be skipped")
@@ -76,10 +129,26 @@ func TestProcessRebase(t *testing.T) {
 
 	t.Run("filters error'd branches", func(t *testing.T) {
 		ch := make(chan *github.PullRequest)
-		ret := processRebase(fakeWorkerCache(func(branch string) (repo.Enqueuer, error) {
-			return fakeEnqueuer(func() repo.Signal { return repo.Signal{Error: errors.New("git: unknown binary")} }), nil
-		}), ch)
-		ch <- &github.PullRequest{}
+		ret := processRebase(repositories{
+			{
+				owner:    "test",
+				name:     "test",
+				mainline: "master",
+				cache: fakeWorkerCache(func(branch string) (repo.Enqueuer, error) {
+					return fakeEnqueuer(func() repo.Signal { return repo.Signal{Error: errors.New("git: unknown binary")} }), nil
+				}),
+			},
+		}, ch)
+		ch <- &github.PullRequest{
+			Base: &github.PullRequestBranch{
+				Repo: &github.Repository{
+					Name: stringVal("test"),
+					Owner: &github.User{
+						Login: stringVal("test"),
+					},
+				},
+			},
+		}
 		close(ch)
 		if v, ok := (<-ret); v != nil || ok {
 			t.Fatal("Expected pull request to be skipped")
@@ -88,10 +157,26 @@ func TestProcessRebase(t *testing.T) {
 
 	t.Run("passes through up2date branches", func(t *testing.T) {
 		ch := make(chan *github.PullRequest)
-		ret := processRebase(fakeWorkerCache(func(branch string) (repo.Enqueuer, error) {
-			return fakeEnqueuer(func() repo.Signal { return repo.Signal{UpToDate: true} }), nil
-		}), ch)
-		ch <- &github.PullRequest{}
+		ret := processRebase(repositories{
+			{
+				owner:    "test",
+				name:     "test",
+				mainline: "master",
+				cache: fakeWorkerCache(func(branch string) (repo.Enqueuer, error) {
+					return fakeEnqueuer(func() repo.Signal { return repo.Signal{UpToDate: true} }), nil
+				}),
+			},
+		}, ch)
+		ch <- &github.PullRequest{
+			Base: &github.PullRequestBranch{
+				Repo: &github.Repository{
+					Name: stringVal("test"),
+					Owner: &github.User{
+						Login: stringVal("test"),
+					},
+				},
+			},
+		}
 		close(ch)
 		if v, ok := (<-ret); v == nil || !ok {
 			t.Fatal("Expected pull request to pass through")

--- a/startup.sh
+++ b/startup.sh
@@ -15,9 +15,7 @@ if [[ "z$PUBLIC_DNS" == "z" ]]; then
 fi
 
 /github-rebase-bot \
- -owner "$GITHUB_OWNER" \
- -repo "$GITHUB_REPO" \
+ -repos "$GITHUB_REPOS" \
  -public-dns http://$PUBLIC_DNS \
  -merge-label "$GITHUB_MERGE_LABEL" \
- -addr :8080 \
- -mainline "$GITHUB_MAINLINE"
+ -addr :8080

--- a/status_event.go
+++ b/status_event.go
@@ -23,7 +23,7 @@ func (b *statusEventBroadcaster) Listen(in <-chan *github.StatusEvent) {
 }
 
 // processMainlineStatusEvent takes mainline status events and emits open PRs
-func processMainlineStatusEvent(repos repositories, client PullRequestLister, input <-chan *github.StatusEvent) <-chan *github.PullRequest {
+func processMainlineStatusEvent(repo repository, client PullRequestLister, input <-chan *github.StatusEvent) <-chan *github.PullRequest {
 	ret := make(chan *github.PullRequest)
 	go func() {
 		for evt := range input {
@@ -31,7 +31,6 @@ func processMainlineStatusEvent(repos repositories, client PullRequestLister, in
 				continue
 			}
 
-			repo := repos.Find(evt.Repo.Owner.GetLogin(), evt.Repo.GetName())
 			isMainline := false
 			for _, branch := range evt.Branches {
 				isMainline = isMainline || *branch.Name == repo.mainline

--- a/status_event.go
+++ b/status_event.go
@@ -23,7 +23,7 @@ func (b *statusEventBroadcaster) Listen(in <-chan *github.StatusEvent) {
 }
 
 // processMainlineStatusEvent takes mainline status events and emits open PRs
-func processMainlineStatusEvent(client PullRequestLister, input <-chan *github.StatusEvent) <-chan *github.PullRequest {
+func processMainlineStatusEvent(repos repositories, client PullRequestLister, input <-chan *github.StatusEvent) <-chan *github.PullRequest {
 	ret := make(chan *github.PullRequest)
 	go func() {
 		for evt := range input {
@@ -31,9 +31,10 @@ func processMainlineStatusEvent(client PullRequestLister, input <-chan *github.S
 				continue
 			}
 
+			repo := repos.Find(evt.Repo.Owner.GetLogin(), evt.Repo.GetName())
 			isMainline := false
 			for _, branch := range evt.Branches {
-				isMainline = isMainline || *branch.Name == mainline
+				isMainline = isMainline || *branch.Name == repo.mainline
 			}
 
 			if !isMainline {
@@ -42,8 +43,8 @@ func processMainlineStatusEvent(client PullRequestLister, input <-chan *github.S
 
 			prs, _, err := client.List(
 				context.Background(),
-				owner,
-				repository,
+				repo.owner,
+				repo.name,
 				&github.PullRequestListOptions{
 					State: "open",
 				})
@@ -71,8 +72,8 @@ func processStatusEvent(client PullRequestLister, input <-chan *github.StatusEve
 
 			prs, _, err := client.List(
 				context.Background(),
-				owner,
-				repository,
+				evt.Repo.Owner.GetLogin(),
+				evt.Repo.GetName(),
 				&github.PullRequestListOptions{
 					State: "open",
 				})

--- a/status_event_test.go
+++ b/status_event_test.go
@@ -35,12 +35,10 @@ func TestProcessMainlineStatusEvent(t *testing.T) {
 	ch := make(chan *github.StatusEvent, 1)
 
 	t.Run("adds open PRs on mainline success", func(t *testing.T) {
-		out := processMainlineStatusEvent(repositories{
-			{
-				owner:    "test",
-				name:     "test",
-				mainline: "master",
-			},
+		out := processMainlineStatusEvent(repository{
+			owner:    "test",
+			name:     "test",
+			mainline: "master",
 		}, fakePullRequestResponse(2), ch)
 		ch <- &github.StatusEvent{
 			State: stringVal("success"),

--- a/status_event_test.go
+++ b/status_event_test.go
@@ -35,13 +35,24 @@ func TestProcessMainlineStatusEvent(t *testing.T) {
 	ch := make(chan *github.StatusEvent, 1)
 
 	t.Run("adds open PRs on mainline success", func(t *testing.T) {
-		mainline = "master"
-		out := processMainlineStatusEvent(fakePullRequestResponse(2), ch)
+		out := processMainlineStatusEvent(repositories{
+			{
+				owner:    "test",
+				name:     "test",
+				mainline: "master",
+			},
+		}, fakePullRequestResponse(2), ch)
 		ch <- &github.StatusEvent{
 			State: stringVal("success"),
 			Branches: []*github.Branch{
 				{
 					Name: stringVal("master"),
+				},
+			},
+			Repo: &github.Repository{
+				Name: stringVal("test"),
+				Owner: &github.User{
+					Login: stringVal("test"),
 				},
 			},
 		}
@@ -70,6 +81,14 @@ func fakePullRequestResponse(n int) fakePullRequestLister {
 				Head: &github.PullRequestBranch{
 					Ref: stringVal("test"),
 				},
+				Base: &github.PullRequestBranch{
+					User: &github.User{
+						Login: stringVal("test"),
+					},
+					Repo: &github.Repository{
+						Name: stringVal("test"),
+					},
+				},
 			})
 		}
 		return reqs, nil, nil
@@ -84,6 +103,12 @@ func TestProcessStatusEvent_Filters(t *testing.T) {
 			prs := processStatusEvent(nil, ch)
 			ch <- &github.StatusEvent{
 				State: stringVal(state),
+				Repo: &github.Repository{
+					Name: stringVal("test"),
+					Owner: &github.User{
+						Login: stringVal("test"),
+					},
+				},
 			}
 			close(ch)
 
@@ -104,6 +129,12 @@ func TestProcessStatusEvent_Filters(t *testing.T) {
 			Branches: []*github.Branch{
 				{Name: stringVal("test")},
 			},
+			Repo: &github.Repository{
+				Name: stringVal("test"),
+				Owner: &github.User{
+					Login: stringVal("test"),
+				},
+			},
 		}
 		close(ch)
 
@@ -121,6 +152,12 @@ func TestProcessStatusEvent_PassThrough(t *testing.T) {
 		State: stringVal("success"),
 		Branches: []*github.Branch{
 			{Name: stringVal("test")},
+		},
+		Repo: &github.Repository{
+			Name: stringVal("test"),
+			Owner: &github.User{
+				Login: stringVal("test"),
+			},
 		},
 	}
 	close(ch)

--- a/verify_pull_request.go
+++ b/verify_pull_request.go
@@ -36,8 +36,8 @@ func verifyPullRequest(issueClient IssueGetter, statusClient StatusGetter, merge
 
 			issue, _, err := issueClient.Get(
 				context.Background(),
-				owner,
-				repository,
+				pr.Base.Repo.Owner.GetLogin(),
+				pr.Base.Repo.GetName(),
 				pr.GetNumber(),
 			)
 			if err != nil {
@@ -55,8 +55,8 @@ func verifyPullRequest(issueClient IssueGetter, statusClient StatusGetter, merge
 
 			status, _, err := statusClient.GetCombinedStatus(
 				context.Background(),
-				owner,
-				repository,
+				pr.Base.Repo.Owner.GetLogin(),
+				pr.Base.Repo.GetName(),
 				*pr.Head.SHA,
 				&github.ListOptions{},
 			)

--- a/verify_pull_request_test.go
+++ b/verify_pull_request_test.go
@@ -28,6 +28,14 @@ func TestVerifyPullRequest_Filters(t *testing.T) {
 		ch <- &github.PullRequest{
 			State:  stringVal("closed"),
 			Number: intVal(1),
+			Base: &github.PullRequestBranch{
+				Repo: &github.Repository{
+					Name: stringVal("test"),
+					Owner: &github.User{
+						Login: stringVal("test"),
+					},
+				},
+			},
 		}
 		close(ch)
 
@@ -49,6 +57,14 @@ func TestVerifyPullRequest_Filters(t *testing.T) {
 		ch <- &github.PullRequest{
 			State:  stringVal("open"),
 			Number: intVal(1),
+			Base: &github.PullRequestBranch{
+				Repo: &github.Repository{
+					Name: stringVal("test"),
+					Owner: &github.User{
+						Login: stringVal("test"),
+					},
+				},
+			},
 		}
 		close(ch)
 
@@ -79,6 +95,14 @@ func TestVerifyPullRequest_Filters(t *testing.T) {
 			Head: &github.PullRequestBranch{
 				Ref: stringVal("test"),
 				SHA: stringVal("098f6bcd4621d373cade4e832627b4f6"),
+			},
+			Base: &github.PullRequestBranch{
+				Repo: &github.Repository{
+					Name: stringVal("test"),
+					Owner: &github.User{
+						Login: stringVal("test"),
+					},
+				},
 			},
 			Mergeable: boolVal(false),
 		}
@@ -111,6 +135,14 @@ func TestVerifyPullRequest_Filters(t *testing.T) {
 			Head: &github.PullRequestBranch{
 				Ref: stringVal("test"),
 				SHA: stringVal("098f6bcd4621d373cade4e832627b4f6"),
+			},
+			Base: &github.PullRequestBranch{
+				Repo: &github.Repository{
+					Name: stringVal("test"),
+					Owner: &github.User{
+						Login: stringVal("test"),
+					},
+				},
 			},
 			Mergeable: boolVal(true),
 		}
@@ -146,6 +178,14 @@ func TestVerifyPullRequest_PassThrough(t *testing.T) {
 		Head: &github.PullRequestBranch{
 			Ref: stringVal("test"),
 			SHA: stringVal("098f6bcd4621d373cade4e832627b4f6"),
+		},
+		Base: &github.PullRequestBranch{
+			Repo: &github.Repository{
+				Name: stringVal("test"),
+				Owner: &github.User{
+					Login: stringVal("test"),
+				},
+			},
 		},
 		Mergeable: boolVal(true),
 	}


### PR DESCRIPTION
this PR enables the bot to support multiple repositories at once. see #6 for the related issue.

the goal of this PR is that …

- [x] the bot can handle any repository in parallel
- [x] every repository can have a configurable mainline

to make this happen the configuration changes a little:

from `-owner test -repo test` to `-repos test/test#master` 

the container for this PR is `nicolai86/github-rebase-bot:pr21-1`