### PR TITLE
feat(bot): guard against case sensitivity

### DIFF
--- a/verify_pull_request.go
+++ b/verify_pull_request.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"strings"
 
 	"github.com/google/go-github/github"
 )
@@ -49,7 +50,7 @@ func verifyPullRequest(issueClient IssueGetter, statusClient StatusGetter, merge
 
 			mergeable := false
 			for _, label := range issue.Labels {
-				mergeable = mergeable || *label.Name == mergeLabel
+				mergeable = mergeable || strings.EqualFold(*label.Name, mergeLabel)
 			}
 
 			if !mergeable || (pr.Mergeable != nil && !*pr.Mergeable) {

--- a/verify_pull_request_test.go
+++ b/verify_pull_request_test.go
@@ -161,7 +161,7 @@ func TestVerifyPullRequest_PassThrough(t *testing.T) {
 	issueClient := fakeIssueGetter(func() (*github.Issue, *github.Response, error) {
 		return &github.Issue{
 			Labels: []github.Label{
-				{Name: stringVal(mergeLabel)},
+				{Name: stringVal("ready to Merge")},
 			},
 		}, nil, nil
 	})


### PR DESCRIPTION
this is a tricky error to spot - when a label is actually cased differently than
the bot configuration. this change ensures that the bot ignores the casing, and
also special characters :tada: