### PR TITLE
chore(bot): force clean branches

### DIFF
--- a/repo/cache.go
+++ b/repo/cache.go
@@ -40,6 +40,7 @@ func (c *Cache) Update() (string, error) {
 	stdout, stderr, err := cmd.Pipeline([]*exec.Cmd{
 		cmd.MustConfigure(exec.Command("git", "fetch", "--all"), c.inCacheDirectory()),
 		cmd.MustConfigure(exec.Command("git", "reset", "--hard", fmt.Sprintf("origin/%s", c.mainline)), c.inCacheDirectory()),
+		cmd.MustConfigure(exec.Command("git", "clean", "-f", "-d", "-x"), c.inCacheDirectory()),
 		cmd.MustConfigure(exec.Command("git", "rev-parse", "HEAD"), c.inCacheDirectory()),
 	}).Run()
 	log.PrintLinesPrefixed(c.mainline, stdout)

--- a/repo/worker.go
+++ b/repo/worker.go
@@ -102,6 +102,7 @@ func (w *Worker) update(dir string) error {
 	stdout, stderr, err := cmd.Pipeline([]*exec.Cmd{
 		cmd.MustConfigure(exec.Command("git", "fetch", "origin", w.branch), inDir(dir)),
 		cmd.MustConfigure(exec.Command("git", "reset", "--hard", fmt.Sprintf("origin/%s", w.branch)), inDir(dir)),
+		cmd.MustConfigure(exec.Command("git", "clean", "-f", "-d", "-x"), inDir(dir)),
 	}).Run()
 	log.PrintLinesPrefixed(w.branch, stdout)
 	log.PrintLinesPrefixed(w.branch, stderr)


### PR DESCRIPTION
sometimes the bot seems to hang, and I have a theory that this is because of a
non-clean git directory.

This change adds `git clean -f -d -x` for the cache as well as the worktree to
make sure it's clean.