### PR TITLE
chore(k8s): update deployment namespace

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: rebase-bot


### PR DESCRIPTION
use `apps` instead of `extensions` to get the rs cleanup